### PR TITLE
Prefer dark theme if not specified

### DIFF
--- a/src/components/theme-switch/index.jsx
+++ b/src/components/theme-switch/index.jsx
@@ -1,45 +1,45 @@
-import React, { useState, useEffect } from 'react'
-import Switch from 'react-switch'
+import React, { useState, useEffect } from 'react';
+import Switch from 'react-switch';
 
-import * as Dom from '../../utils/dom'
-import { THEME } from '../../constants'
+import * as Dom from '../../utils/dom';
+import { THEME } from '../../constants';
 
-import './index.scss'
+import './index.scss';
 
 function getTheme(checked) {
-  return checked ? THEME.DARK : THEME.LIGHT
+  return checked ? THEME.DARK : THEME.LIGHT;
 }
 
 function toggleTheme(theme) {
   switch (theme) {
     case THEME.LIGHT: {
-      Dom.addClassToBody(THEME.LIGHT)
-      Dom.removeClassToBody(THEME.DARK)
-      break
+      Dom.addClassToBody(THEME.LIGHT);
+      Dom.removeClassToBody(THEME.DARK);
+      break;
     }
     case THEME.DARK: {
-      Dom.addClassToBody(THEME.DARK)
-      Dom.removeClassToBody(THEME.LIGHT)
-      break
+      Dom.addClassToBody(THEME.DARK);
+      Dom.removeClassToBody(THEME.LIGHT);
+      break;
     }
   }
 }
 
 export const ThemeSwitch = () => {
-  const [checked, setChecked] = useState(false)
+  const [checked, setChecked] = useState(false);
 
   const handleChange = checked => {
-    const theme = getTheme(checked)
+    const theme = getTheme(checked);
 
-    setChecked(checked)
-    toggleTheme(theme)
-  }
+    setChecked(checked);
+    toggleTheme(theme);
+  };
 
   useEffect(() => {
-    const checked = Dom.hasClassOfBody(THEME.DARK)
+    const checked = Dom.hasClassOfBody(THEME.DARK);
 
-    handleChange(checked)
-  }, [])
+    handleChange(checked);
+  }, []);
 
   return (
     <div className="switch-container">
@@ -59,5 +59,5 @@ export const ThemeSwitch = () => {
         />
       </label>
     </div>
-  )
-}
+  );
+};

--- a/src/components/theme-switch/index.jsx
+++ b/src/components/theme-switch/index.jsx
@@ -7,10 +7,11 @@ import { THEME } from '../../constants';
 import './index.scss';
 
 function getTheme(checked) {
-  return checked ? THEME.DARK : THEME.LIGHT;
+  return checked ? THEME.LIGHT : THEME.DARK;
 }
 
 function toggleTheme(theme) {
+  console.log(theme);
   switch (theme) {
     case THEME.LIGHT: {
       Dom.addClassToBody(THEME.LIGHT);
@@ -36,7 +37,7 @@ export const ThemeSwitch = () => {
   };
 
   useEffect(() => {
-    const checked = Dom.hasClassOfBody(THEME.DARK);
+    const checked = Dom.hasClassOfBody(THEME.LIGHT);
 
     handleChange(checked);
   }, []);
@@ -50,12 +51,12 @@ export const ThemeSwitch = () => {
           id="normal-switch"
           height={24}
           width={48}
-          checkedIcon={<div className="icon checkedIcon">D</div>}
-          uncheckedIcon={<div className="icon uncheckedIcon">L</div>}
-          offColor={'#d9dfe2'}
-          offHandleColor={'#fff'}
-          onColor={'#999'}
-          onHandleColor={'#282c35'}
+          uncheckedIcon={<div className="icon uncheckedIcon">D</div>}
+          checkedIcon={<div className="icon checkedIcon">L</div>}
+          onColor={'#d9dfe2'}
+          onHandleColor={'#fff'}
+          offColor={'#999'}
+          offHandleColor={'#282c35'}
         />
       </label>
     </div>


### PR DESCRIPTION
**TLDR:** 
Successfully implemented request as we discussed

**Details:**
The fix was kind of hacky. It'd would be preferred to set initial state of `checked` to `true` and apply `useEffect` if `checked` changes, however it seems that although this would work in react, it doesn't translate properly over to multi-page gastby. Ergo, I swapped the dark and light theme switches and the check for it.